### PR TITLE
Add Blank Test Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+coverage

--- a/src/challengeComponents/asyncApp/__tests__/asyncApp.test.js
+++ b/src/challengeComponents/asyncApp/__tests__/asyncApp.test.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { AsyncApp } from '../asyncApp';
+
+test('test description', () => {});

--- a/src/challengeComponents/button/__tests__/button.test.js
+++ b/src/challengeComponents/button/__tests__/button.test.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Button } from '../button';
+
+test('test description', () => {});

--- a/src/challengeComponents/card/__tests__/card.test.js
+++ b/src/challengeComponents/card/__tests__/card.test.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Card } from '../card';
+
+test('test description', () => {});

--- a/src/challengeComponents/errorMessage/__tests__/errorMessage.test.js
+++ b/src/challengeComponents/errorMessage/__tests__/errorMessage.test.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { ErrorMessage } from '../errorMessage';
+
+test('test description', () => {});

--- a/src/challengeComponents/groupedUserCards/__tests__/groupedUserCards.test.js
+++ b/src/challengeComponents/groupedUserCards/__tests__/groupedUserCards.test.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { GroupedUserCards } from '../groupedUserCards';
+
+test('test description', () => {});

--- a/src/challengeComponents/layout/__tests__/layout.test.js
+++ b/src/challengeComponents/layout/__tests__/layout.test.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Layout } from '../layout';
+
+test('test description', () => {});

--- a/src/challengeComponents/saveUsersAppLayout/__tests__/saveUsersAppLayout.test.js
+++ b/src/challengeComponents/saveUsersAppLayout/__tests__/saveUsersAppLayout.test.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { SaveUsersAppLayout } from '../saveUsersAppLayout';
+
+test('test description', () => {});

--- a/src/challengeComponents/savedUsersList/__tests__/savedUsersList.test.js
+++ b/src/challengeComponents/savedUsersList/__tests__/savedUsersList.test.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { SavedUsersList } from '../savedUsersList';
+
+test('test description', () => {});

--- a/src/challengeComponents/sectionTitle/__tests__/sectionTitle.test.js
+++ b/src/challengeComponents/sectionTitle/__tests__/sectionTitle.test.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { SectionTitle } from '../sectionTitle';
+
+test('test description', () => {});

--- a/src/challengeComponents/sideBar/__tests__/sideBar.test.js
+++ b/src/challengeComponents/sideBar/__tests__/sideBar.test.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { SideBar } from '../sideBar';
+
+test('test description', () => {});

--- a/src/challengeComponents/staticApp/__tests__/staticApp.test.js
+++ b/src/challengeComponents/staticApp/__tests__/staticApp.test.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { StaticApp } from '../staticApp';
+
+test('test description', () => {});

--- a/src/challengeComponents/staticApp/staticApp.js
+++ b/src/challengeComponents/staticApp/staticApp.js
@@ -1,7 +1,17 @@
 import React, { Component } from "react";
+import PropTypes from 'prop-types';
 import { SaveUsersAppLayout } from "../saveUsersAppLayout/saveUsersAppLayout";
 
 export class StaticApp extends Component {
+
+  static propTypes = {
+    data: PropTypes.object
+  }
+
+  static defaultProps = {
+    data: {}
+  }
+
   state = {
     savedUsers: null
   };

--- a/src/challengeComponents/userCard/__tests__/userCard.test.js
+++ b/src/challengeComponents/userCard/__tests__/userCard.test.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { UserCard } from '../userCard';
+
+test('test description', () => {});

--- a/src/challengeComponents/utilities/__tests__/utilities.test.js
+++ b/src/challengeComponents/utilities/__tests__/utilities.test.js
@@ -1,0 +1,9 @@
+import classNames from '../classNames';
+import { fetchUsers } from '../fetchUsers';
+import { formatUserData } from '../formatUserData';
+import { getEnzymeAttributeSelector } from '../testUtils';
+import { mockUserData, formattedUserData, usersProps } from '../mockUserData';
+
+describe('classNames', () => {
+  it('test description', () => {});
+});

--- a/src/enzymeSetup.js
+++ b/src/enzymeSetup.js
@@ -1,4 +1,0 @@
-import Enzyme from "enzyme";
-import Adapter from "enzyme-adapter-react-16";
-
-Enzyme.configure({ adapter: new Adapter() });

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/src/sharedComponents/exercises/exercises.js
+++ b/src/sharedComponents/exercises/exercises.js
@@ -1,10 +1,10 @@
-import React, { useEffect } from 'react';
-import { Card } from '../../challengeComponents/card/card';
-import { SectionTitle } from '../../challengeComponents/sectionTitle/sectionTitle';
-import { Button } from '../../challengeComponents/button/button';
-import { navigate } from '@reach/router';
-import Highlight from 'react-highlight';
-import './exercises.css';
+import React, { useEffect } from "react";
+import { Card } from "../../challengeComponents/card/card";
+import { SectionTitle } from "../../challengeComponents/sectionTitle/sectionTitle";
+import { Button } from "../../challengeComponents/button/button";
+import { navigate } from "@reach/router";
+import Highlight from "react-highlight";
+import "./exercises.css";
 
 export const Exercises = () => {
   useEffect(() => {
@@ -26,16 +26,16 @@ export const Exercises = () => {
             headingLevel={2}
           />
           <p className="Exercises-cardCriteria">Link</p>
-          <Button type="text" onClick={() => navigate('/exerciseOne')}>
+          <Button type="text" onClick={() => navigate("/exerciseOne")}>
             Save Users App (hydrated with props)
           </Button>
           <p className="Exercises-cardCriteria">Goal</p>
           <p>
-            React gives us the power to build and compose small, modular
-            elements into larger pieces. Covering these core components with
-            tests has an outsized impact because they are re-used so often.
-            Let's build an understanding of component testing by writing tests
-            for our most basic elements.
+            React gives us the power to build and compose small, modular elements
+            into larger pieces. Covering these core components with tests has an
+            outsized impact because they are re-used so often. Let's build an
+            understanding of component testing by writing tests for our most
+            basic elements.
           </p>
           <p className="Exercises-cardCriteria">Acceptance Criteria:</p>
           <p>
@@ -110,7 +110,7 @@ test("renders title text", () => {
             headingLevel={2}
           />
           <p className="Exercises-cardCriteria">Link</p>
-          <Button type="text" onClick={() => navigate('/exerciseOne')}>
+          <Button type="text" onClick={() => navigate("/exerciseOne")}>
             Save Users App (hydrated with props)
           </Button>
           <p className="Exercises-cardCriteria">Goal</p>
@@ -156,7 +156,7 @@ import {formattedUserData, mockUserData} from '../../utilities/mockUserData'
             headingLevel={2}
           />
           <p className="Exercises-cardCriteria">Link</p>
-          <Button type="text" onClick={() => navigate('/exerciseOne')}>
+          <Button type="text" onClick={() => navigate("/exerciseOne")}>
             Save Users App (hydrated with props)
           </Button>
           <p className="Exercises-cardCriteria">Goal</p>
@@ -190,14 +190,14 @@ import {formattedUserData, mockUserData} from '../../utilities/mockUserData'
           <p className="Exercises-cardCriteria">Implementation Details:</p>
           There's a saying in frontend testing - "Don't test internals". This is
           another way of saying not to test component internals. The excellent
-          Kent C. Dodds wrote an excellent article{' '}
+          Kent C. Dodds wrote an excellent article{" "}
           <a
             href="https://kentcdodds.com/blog/testing-implementation-details"
             target="_blank"
             rel="noopener noreferrer"
           >
             here
-          </a>{' '}
+          </a>{" "}
           that dives deep into that concept. Please read this article before you
           work on this larger scale integration-like test.
           <p />
@@ -217,7 +217,7 @@ import {formattedUserData, mockUserData} from '../../utilities/mockUserData'
             headingLevel={2}
           />
           <p className="Exercises-cardCriteria">Link</p>
-          <Button type="text" onClick={() => navigate('/exerciseTwo')}>
+          <Button type="text" onClick={() => navigate("/exerciseTwo")}>
             Save Users App (hydrated with a fetch call)
           </Button>
           <p className="Exercises-cardCriteria">Goal</p>
@@ -264,28 +264,28 @@ import {formattedUserData, mockUserData} from '../../utilities/mockUserData'
               the AsyncApp component. This gives us the power to test AsyncApp
               with a mock version of fetchUsers that we can control. You will
               need to leverage this, and Jest mocks to write a successful test
-              the first part of this exercise. More info on jest mocks{' '}
+              the first part of this exercise. More info on jest mocks{" "}
               <a
                 href="https://jestjs.io/docs/en/mock-function-api.html#mockfnmockresolvedvaluevalue"
                 target="_blank"
                 rel="noopener noreferrer"
               >
                 here
-              </a>{' '}
+              </a>{" "}
             </li>
             <li className="Exercises-listItem">
               Wait-for-expect: We've provided this library to help you test
               AsyncApp's data fetching component. Because this component relies
               on async actions to fetch data, we need a way to wait for the
               promise to resolve before we can make any assertions. This library
-              helps us do that in a controlled way. More info{' '}
+              helps us do that in a controlled way. More info{" "}
               <a
                 href="https://github.com/TheBrainFamily/wait-for-expect"
                 target="_blank"
                 rel="noopener noreferrer"
               >
                 here
-              </a>{' '}
+              </a>{" "}
             </li>
             <li className="Exercises-listItem">
               Multiple exports: If you look at the AsyncApp exports, you will
@@ -305,7 +305,7 @@ import {formattedUserData, mockUserData} from '../../utilities/mockUserData'
             headingLevel={2}
           />
           <p className="Exercises-cardCriteria">Link</p>
-          <Button type="text" onClick={() => navigate('/exerciseTwo')}>
+          <Button type="text" onClick={() => navigate("/exerciseTwo")}>
             Save Users App (hydrated with a fetch call)
           </Button>
           <p className="Exercises-cardCriteria">Goal</p>

--- a/src/sharedComponents/exercises/exercises.js
+++ b/src/sharedComponents/exercises/exercises.js
@@ -188,8 +188,8 @@ import {formattedUserData, mockUserData} from '../../utilities/mockUserData'
             </li>
           </ul>
           <p className="Exercises-cardCriteria">Implementation Details:</p>
-          There's a saying in frontend testing - "Don't test internals". This is
-          another way of saying not to test component internals. The excellent
+          There's a saying in testing - "Don't test internals". This is another
+          way of saying not to test component internals. The excellent
           Kent C. Dodds wrote an excellent article{" "}
           <a
             href="https://kentcdodds.com/blog/testing-implementation-details"

--- a/src/sharedComponents/exercises/exercises.js
+++ b/src/sharedComponents/exercises/exercises.js
@@ -1,10 +1,10 @@
-import React, { useEffect } from "react";
-import { Card } from "../../challengeComponents/card/card";
-import { SectionTitle } from "../../challengeComponents/sectionTitle/sectionTitle";
-import { Button } from "../../challengeComponents/button/button";
-import { navigate } from "@reach/router";
-import Highlight from "react-highlight";
-import "./exercises.css";
+import React, { useEffect } from 'react';
+import { Card } from '../../challengeComponents/card/card';
+import { SectionTitle } from '../../challengeComponents/sectionTitle/sectionTitle';
+import { Button } from '../../challengeComponents/button/button';
+import { navigate } from '@reach/router';
+import Highlight from 'react-highlight';
+import './exercises.css';
 
 export const Exercises = () => {
   useEffect(() => {
@@ -26,16 +26,16 @@ export const Exercises = () => {
             headingLevel={2}
           />
           <p className="Exercises-cardCriteria">Link</p>
-          <Button type="text" onClick={() => navigate("/exerciseOne")}>
+          <Button type="text" onClick={() => navigate('/exerciseOne')}>
             Save Users App (hydrated with props)
           </Button>
           <p className="Exercises-cardCriteria">Goal</p>
           <p>
-            Reat gives us the power to build and compose small, modular elements
-            into larger pieces. Covering these core components with tests has an
-            outsized impact because they are re-used so often. Let's build an
-            understanding of component testing by writing tests for our most
-            basic elements.
+            React gives us the power to build and compose small, modular
+            elements into larger pieces. Covering these core components with
+            tests has an outsized impact because they are re-used so often.
+            Let's build an understanding of component testing by writing tests
+            for our most basic elements.
           </p>
           <p className="Exercises-cardCriteria">Acceptance Criteria:</p>
           <p>
@@ -110,7 +110,7 @@ test("renders title text", () => {
             headingLevel={2}
           />
           <p className="Exercises-cardCriteria">Link</p>
-          <Button type="text" onClick={() => navigate("/exerciseOne")}>
+          <Button type="text" onClick={() => navigate('/exerciseOne')}>
             Save Users App (hydrated with props)
           </Button>
           <p className="Exercises-cardCriteria">Goal</p>
@@ -156,7 +156,7 @@ import {formattedUserData, mockUserData} from '../../utilities/mockUserData'
             headingLevel={2}
           />
           <p className="Exercises-cardCriteria">Link</p>
-          <Button type="text" onClick={() => navigate("/exerciseOne")}>
+          <Button type="text" onClick={() => navigate('/exerciseOne')}>
             Save Users App (hydrated with props)
           </Button>
           <p className="Exercises-cardCriteria">Goal</p>
@@ -190,14 +190,14 @@ import {formattedUserData, mockUserData} from '../../utilities/mockUserData'
           <p className="Exercises-cardCriteria">Implementation Details:</p>
           There's a saying in frontend testing - "Don't test internals". This is
           another way of saying not to test component internals. The excellent
-          Kent C. Dodds wrote an excellent article{" "}
+          Kent C. Dodds wrote an excellent article{' '}
           <a
             href="https://kentcdodds.com/blog/testing-implementation-details"
             target="_blank"
             rel="noopener noreferrer"
           >
             here
-          </a>{" "}
+          </a>{' '}
           that dives deep into that concept. Please read this article before you
           work on this larger scale integration-like test.
           <p />
@@ -217,7 +217,7 @@ import {formattedUserData, mockUserData} from '../../utilities/mockUserData'
             headingLevel={2}
           />
           <p className="Exercises-cardCriteria">Link</p>
-          <Button type="text" onClick={() => navigate("/exerciseTwo")}>
+          <Button type="text" onClick={() => navigate('/exerciseTwo')}>
             Save Users App (hydrated with a fetch call)
           </Button>
           <p className="Exercises-cardCriteria">Goal</p>
@@ -264,28 +264,28 @@ import {formattedUserData, mockUserData} from '../../utilities/mockUserData'
               the AsyncApp component. This gives us the power to test AsyncApp
               with a mock version of fetchUsers that we can control. You will
               need to leverage this, and Jest mocks to write a successful test
-              the first part of this exercise. More info on jest mocks{" "}
+              the first part of this exercise. More info on jest mocks{' '}
               <a
                 href="https://jestjs.io/docs/en/mock-function-api.html#mockfnmockresolvedvaluevalue"
                 target="_blank"
                 rel="noopener noreferrer"
               >
                 here
-              </a>{" "}
+              </a>{' '}
             </li>
             <li className="Exercises-listItem">
               Wait-for-expect: We've provided this library to help you test
               AsyncApp's data fetching component. Because this component relies
               on async actions to fetch data, we need a way to wait for the
               promise to resolve before we can make any assertions. This library
-              helps us do that in a controlled way. More info{" "}
+              helps us do that in a controlled way. More info{' '}
               <a
                 href="https://github.com/TheBrainFamily/wait-for-expect"
                 target="_blank"
                 rel="noopener noreferrer"
               >
                 here
-              </a>{" "}
+              </a>{' '}
             </li>
             <li className="Exercises-listItem">
               Multiple exports: If you look at the AsyncApp exports, you will
@@ -305,7 +305,7 @@ import {formattedUserData, mockUserData} from '../../utilities/mockUserData'
             headingLevel={2}
           />
           <p className="Exercises-cardCriteria">Link</p>
-          <Button type="text" onClick={() => navigate("/exerciseTwo")}>
+          <Button type="text" onClick={() => navigate('/exerciseTwo')}>
             Save Users App (hydrated with a fetch call)
           </Button>
           <p className="Exercises-cardCriteria">Goal</p>

--- a/src/sharedComponents/exercises/exercises.js
+++ b/src/sharedComponents/exercises/exercises.js
@@ -260,7 +260,6 @@ import {formattedUserData, mockUserData} from '../../utilities/mockUserData'
           <ul className="Exercises-list">
             <li className="Exercises-listItem">
               Dependency Injection: We've passed in our fetch call as a prop to
-              >Dependency Injection: We've passed in our fetch call as a prop to
               the AsyncApp component. This gives us the power to test AsyncApp
               with a mock version of fetchUsers that we can control. You will
               need to leverage this, and Jest mocks to write a successful test

--- a/src/sharedComponents/exercises/exercises.js
+++ b/src/sharedComponents/exercises/exercises.js
@@ -182,7 +182,7 @@ import {formattedUserData, mockUserData} from '../../utilities/mockUserData'
               Test that clicking the "X" button on a SavedUsersList user item
               removes that user from the SavedUsersList.
             </li>
-            <li>
+            <li className="Exercises-listItem">
               Test that GroupedUserCards recieves the savedUserIds prop with the
               right saved user ids once you have a saved user.
             </li>

--- a/src/sharedComponents/exercises/exercises.js
+++ b/src/sharedComponents/exercises/exercises.js
@@ -163,7 +163,7 @@ import {formattedUserData, mockUserData} from '../../utilities/mockUserData'
           <p>
             We have testing coverage for all of our pieces. Now it's time to put
             it all together and write something closer to an integration test.
-            This exercise will require you to mount the app, perform simulated
+            This exercise will require you to mount StaticApp, perform simulated
             exercises, and assert the proper user interfaces updated in the
             proper way.
           </p>

--- a/src/solutions/__tests__/classNames.test.js
+++ b/src/solutions/__tests__/classNames.test.js
@@ -1,14 +1,13 @@
-import Adapter from "../../enzymeSetup";
-import classNames from "../../challengeComponents/utilities/classNames";
+import classNames from '../../challengeComponents/utilities/classNames';
 
-describe.skip("classNames utility", () => {
-  it("creates the right classname", () => {
+describe.skip('classNames utility', () => {
+  it('creates the right classname', () => {
     expect(
       classNames({
         BaseClassName: true,
-        "BaseClassName--modifier": false,
-        "BaseClassName--otherModifier": true
+        'BaseClassName--modifier': false,
+        'BaseClassName--otherModifier': true,
       })
-    ).toBe("BaseClassName BaseClassName--otherModifier");
+    ).toBe('BaseClassName BaseClassName--otherModifier');
   });
 });


### PR DESCRIPTION
I thought it might be good to set up some blank test files, since there are a bunch of empty test folders in the CodeSandbox.

Made a few other tweaks:
- added `node_modules` and `coverage` to `.gitignore` (just for local development)
- renamed `enzymeSetup` to `setupTests` - If you have a `src/setupTests.js`, jest will recognize it as the Enzyme config without needing a jest config (again, this was just to help local development)
- Fixed a few things in the exercises page

Feel free to leave comments or decline the PR if any of this stuff was intentionally set up this way!